### PR TITLE
Update API response handling for new UTXO/balance format

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -76,6 +76,16 @@
   gap: 8px;
 }
 
+.block-height {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #64748b;
+  background: rgba(100, 116, 139, 0.1);
+  padding: 4px 8px;
+  border-radius: 6px;
+  margin-left: 8px;
+}
+
 .loading-spinner {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Purpose

The latest-utxo and top-balances APIs have changed their response format from a structured object format to a simplified key-value pair format. The user needed to update the application to handle this new API structure while also displaying the block height information from the latest-utxo API response alongside the "Latest UTXO" header.

## Code changes

- **API Response Processing**: Updated `fetchUtxos()` and `fetchBalances()` functions to handle the new simplified API response format where data is returned as key-value pairs instead of structured objects
- **Block Height Display**: Added extraction and display of `blockHeight` from the first item in the latest-utxo API response
- **State Management**: Added `blockHeight` state variable to track and display the current block height
- **UI Enhancement**: Added `.block-height` CSS class for styling the block height display with a subtle badge appearance
- **Header Update**: Modified the "Latest UTXO" section header to include the block height in parentheses when available
- **Backward Compatibility**: Maintained fallback support for the old API structure in case the new format is not detected

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/909e073c38d44c02a15a52c645a08dc3/zenith-den)

👀 [Preview Link](https://909e073c38d44c02a15a52c645a08dc3-zenith-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>909e073c38d44c02a15a52c645a08dc3</projectId>-->
<!--<branchName>zenith-den</branchName>-->